### PR TITLE
unzip ".kmz" input files

### DIFF
--- a/KMLtoOSMAndGPX.py
+++ b/KMLtoOSMAndGPX.py
@@ -23,6 +23,7 @@ import argparse
 import xml.etree.ElementTree as ET
 from xml.dom import minidom
 import ntpath
+from zipfile import ZipFile
 
 PROGRAM_VERSION = "2.3"
 DEFAULT_TRACK_TRANSPARENCY = "80"
@@ -460,7 +461,12 @@ def main():
 	print("Starting conversion...")
 
 	# Parse the KML file
-	tree = ET.parse(args.kml_file)
+	kml_filename,kml_ext=ntpath.splitext(args.kml_file)
+	if kml_ext.upper()=='.KMZ':
+		with ZipFile(args.kml_file).open('doc.kml','r') as kml_doc:
+			tree=ET.parse(kml_doc)
+	else:
+		tree = ET.parse(args.kml_file)
 	root = tree.getroot()
 	# process the KML file a folder at a time.  If the -l flag is specified each folder's data
 	# will get written to a separate GPX file.  If the -l flag is not specifgied than all


### PR DESCRIPTION
A small change that allows ".kmz" files as input files.
I have tested it on my iPad, and on MyBinder (online IPython Notebook, under Linux).
It should also work for Windows, but I have not tested it.
Here is a link to the "Mybinder" interactive online version with a IPython Notebook "test.ipynb":
[![Run Jupyter Notebooks](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/RichardPotthoff/KMLtoOSMAndGPX/kmz_mybinder?filepath=./)